### PR TITLE
废弃 bean-report 的使用

### DIFF
--- a/script/config.go
+++ b/script/config.go
@@ -484,11 +484,8 @@ type CommodityPrice struct {
 	Value     string `json:"value"`
 }
 
-func RefreshLedgerCurrency(ledgerConfig *Config) []LedgerCurrency {
-	// 查询货币获取当前汇率
-	output := BeanReportAllPrices(ledgerConfig)
-	statsPricesResultList := make([]CommodityPrice, 0)
-	lines := strings.Split(output, "\n")
+func newCommodityPriceListFromString(lines []string) []CommodityPrice {
+	commodityPriceList := make([]CommodityPrice, 0, len(lines))
 	// foreach lines
 	for _, line := range lines {
 		if strings.Trim(line, " ") == "" {
@@ -496,14 +493,19 @@ func RefreshLedgerCurrency(ledgerConfig *Config) []LedgerCurrency {
 		}
 		// split line by " "
 		words := strings.Fields(line)
-		statsPricesResultList = append(statsPricesResultList, CommodityPrice{
+		commodityPriceList = append(commodityPriceList, CommodityPrice{
 			Date:      words[0],
 			Commodity: words[2],
 			Value:     words[3],
 			Currency:  words[4],
 		})
 	}
+	return commodityPriceList
+}
 
+func RefreshLedgerCurrency(ledgerConfig *Config) []LedgerCurrency {
+	// 查询货币获取当前汇率
+	statsPricesResultList := BeanReportAllPrices(ledgerConfig)
 	// statsPricesResultList 转为 map
 	existCurrencyMap := make(map[string]CommodityPrice)
 	for _, statsPricesResult := range statsPricesResultList {

--- a/script/utils.go
+++ b/script/utils.go
@@ -4,8 +4,15 @@ import (
 	"bytes"
 	"math/rand"
 	"net"
+	"os/exec"
 	"time"
 )
+
+func checkCommandExists(command string) bool {
+	cmd := exec.Command(command, "--version")
+	_, err := cmd.Output()
+	return err == nil
+}
 
 func GetIpAddress() string {
 	addrs, _ := net.InterfaceAddrs()
@@ -53,7 +60,7 @@ func getTimeStamp(str_date string) Timestamp {
 	return Timestamp(the_time.Unix())
 }
 
-//获取1到2个日期字符串中更大的日期
+// 获取1到2个日期字符串中更大的日期
 func getMaxDate(str_date1 string, str_date2 string) string {
 	var max_date string
 	if str_date1 != "" && str_date2 == "" {

--- a/service/stats.go
+++ b/service/stats.go
@@ -480,33 +480,6 @@ func StatsPayee(c *gin.Context) {
 	OK(c, result)
 }
 
-type StatsPricesResult struct {
-	Date      string `json:"date"`
-	Commodity string `json:"commodity"`
-	Currency  string `json:"operatingCurrency"`
-	Value     string `json:"value"`
-}
-
 func StatsCommodityPrice(c *gin.Context) {
-	ledgerConfig := script.GetLedgerConfigFromContext(c)
-	output := script.BeanReportAllPrices(ledgerConfig)
-	script.LogInfo(ledgerConfig.Mail, output)
-
-	statsPricesResultList := make([]StatsPricesResult, 0)
-	lines := strings.Split(output, "\n")
-	// foreach lines
-	for _, line := range lines {
-		if strings.Trim(line, " ") == "" {
-			continue
-		}
-		// split line by " "
-		words := strings.Fields(line)
-		statsPricesResultList = append(statsPricesResultList, StatsPricesResult{
-			Date:      words[0],
-			Commodity: words[2],
-			Value:     words[3],
-			Currency:  words[4],
-		})
-	}
-	OK(c, statsPricesResultList)
+	OK(c, script.BeanReportAllPrices(script.GetLedgerConfigFromContext(c)))
 }


### PR DESCRIPTION
如 https://github.com/beancount/beancount/issues/832 提到的，`bean-report` 已经从最新的 v3 版本中被废弃，所以本 PR 使用 `bean-query` 实现等价的功能。

改动包括：

- 检测 `bean-report` 命令是否存在来决定使用何种命令进行 Commodities/Currencies 的查询。
- 删除了一些重复的代码。

后续验证 `bean-query` 实现无误后可以再升级 beancount 的支持版本到最新的 v3。

我本地建了一个新账本来测试了 `/api/auth/commodity/currencies` 接口，看起来可以正常工作：

![](https://github.com/user-attachments/assets/7ecab1d4-2ecf-49a2-9e6f-be8028528cf1)

另一个用到该功能的 `/stats/commodity/price` 接口我不确定在哪个界面有调用，所以暂时还没有测试。